### PR TITLE
Add merging for Regions2D

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Save the EVR file as a JSON or CSV file.
 >>> r2d.to_json()
 
 >>> # Save to CSV inside a folder called 'output'
->>> r2d.to_csv(save_dir='output')
+>>> r2d.to_csv(save_path='output')
 ```
 Or call `parse_file` to store the regions data to `Regions2D.output_data` without saving a file to your disk.
 

--- a/docs/source/api/echoregions.formats.Regions2D.rst
+++ b/docs/source/api/echoregions.formats.Regions2D.rst
@@ -13,7 +13,7 @@ Regions2D
       ~Regions2D.max_depth
       ~Regions2D.min_depth
       ~Regions2D.output_data
-      ~Regions2D.output_path
+      ~Regions2D.output_file
       ~Regions2D.plotter
       ~Regions2D.raw_range
       ~Regions2D.region_classifications
@@ -40,7 +40,7 @@ Regions2D
    .. autoattribute:: max_depth
    .. autoattribute:: min_depth
    .. autoattribute:: output_data
-   .. autoattribute:: output_path
+   .. autoattribute:: output_file
    .. autoattribute:: plotter
    .. autoattribute:: raw_range
    .. autoattribute:: region_classifications

--- a/echoregions/__init__.py
+++ b/echoregions/__init__.py
@@ -1,4 +1,6 @@
 from .convert.ecs_parser import CalibrationParser
 from .convert.evl_parser import LineParser
 from .convert.utils import parse_time, parse_filetime, from_JSON
+from .convert.merge import merge
 from .formats.regions2d import Regions2D
+from .formats.multi import MultiRegions2D

--- a/echoregions/convert/ecs_parser.py
+++ b/echoregions/convert/ecs_parser.py
@@ -135,4 +135,4 @@ class CalibrationParser(EvParserBase):
 
         # Export to csv
         df.to_csv(save_path, index=False)
-        self._output_path.append(save_path)
+        self._output_file.append(save_path)

--- a/echoregions/convert/ecs_parser.py
+++ b/echoregions/convert/ecs_parser.py
@@ -2,6 +2,7 @@ import pandas as pd
 import numpy as np
 from .ev_parser import EvParserBase
 import os
+from .utils import validate_path
 
 
 class CalibrationParser(EvParserBase):
@@ -79,13 +80,13 @@ class CalibrationParser(EvParserBase):
             'localcal_settings': localcal_settings,
         }
 
-    def to_csv(self, save_dir=None, **kwargs):
+    def to_csv(self, save_path=None, **kwargs):
         """Convert an Echoview calibration .ecs file to a .csv file
 
         Parameters
         ----------
-        save_dir : str
-            directory to save the CSV file to
+        save_path : str
+            path to save the CSV file to
         kwargs
             keyword arguments passed into `parse_file`
         """
@@ -100,7 +101,7 @@ class CalibrationParser(EvParserBase):
             self.parse_file(**kwargs)
 
         # Check if the save directory is safe
-        save_dir = self._validate_path(save_dir)
+        save_path = validate_path(save_path=save_path, input_file=self.input_file, ext='.csv')
 
         df = pd.DataFrame()
         id_keys = ['value_source', 'channel']
@@ -133,6 +134,5 @@ class CalibrationParser(EvParserBase):
             df = df.append([row_fileset, row_sourcecal, row_localset], ignore_index=True)
 
         # Export to csv
-        output_file_path = os.path.join(save_dir, self.filename) + '.csv'
-        df.to_csv(output_file_path, index=False)
-        self._output_path.append(output_file_path)
+        df.to_csv(save_path, index=False)
+        self._output_path.append(save_path)

--- a/echoregions/convert/ev_parser.py
+++ b/echoregions/convert/ev_parser.py
@@ -53,6 +53,8 @@ class EvParserBase():
         """Base method for parsing the file in `input_file`.
         Used for EVR and EVL parsers
         """
+        if self.input_file is None:
+            return
         fid = open(self.input_file, encoding='utf-8-sig')
 
         metadata, data = self._parse(fid, **kwargs)

--- a/echoregions/convert/ev_parser.py
+++ b/echoregions/convert/ev_parser.py
@@ -8,7 +8,7 @@ class EvParserBase():
         self._input_file = None
         self._filename = None
         self.output_data = {}
-        self._output_path = []
+        self._output_file = []
 
         self.format = file_format
         self.input_file = input_file
@@ -33,12 +33,12 @@ class EvParserBase():
             self._input_file = file
 
     @property
-    def output_path(self):
-        if len(self._output_path) == 1:
-            self._output_path = list(set(self._output_path))
-            return self._output_path[0]
+    def output_file(self):
+        if len(self._output_file) == 1:
+            self._output_file = list(set(self._output_file))
+            return self._output_file[0]
         else:
-            return self._output_path
+            return self._output_file
 
     @staticmethod
     def read_line(open_file, split=False):
@@ -91,7 +91,7 @@ class EvParserBase():
         # Save the entire parsed EVR dictionary as a JSON file
         with open(save_path, 'w') as f:
             f.write(json.dumps(self.output_data, indent=indent))
-        self._output_path.append(str(save_path))
+        self._output_file.append(str(save_path))
 
     def to_csv(self):
         """Base method for saving to a csv file"""

--- a/echoregions/convert/ev_parser.py
+++ b/echoregions/convert/ev_parser.py
@@ -1,5 +1,6 @@
 import json
 import os
+from .utils import validate_path
 
 
 class EvParserBase():
@@ -48,19 +49,6 @@ class EvParserBase():
         else:
             return open_file.readline().strip()
 
-    def _validate_path(self, save_dir=None):
-        # Checks a path to see if it is a folder that exists.
-        # Create the folder if it doesn't
-        if save_dir is None:
-            save_dir = os.path.dirname(self.input_file[0])
-        else:
-            if not os.path.isdir(save_dir):
-                if os.path.splitext(save_dir)[1] == '':
-                    os.mkdir(save_dir)
-                else:
-                    raise ValueError(f"{save_dir} is not a valid save directory")
-        return save_dir
-
     def parse_file(self, **kwargs):
         """Base method for parsing the file in `input_file`.
         Used for EVR and EVL parsers
@@ -80,13 +68,13 @@ class EvParserBase():
             data_name: data
         }
 
-    def to_json(self, save_dir=None, pretty=False, **kwargs):
+    def to_json(self, save_path=None, pretty=False, **kwargs):
         """Convert an Echoview 2D regions .evr file to a .json file
 
         Parameters
         ----------
-        save_dir : str
-            directory to save the JSON file to
+        save_path : str
+            path to save the JSON file to
         pretty : bool
             Whether to output more human readable JSON
         kwargs
@@ -97,14 +85,13 @@ class EvParserBase():
             self.parse_file(**kwargs)
 
         # Check if the save directory is safe
-        save_dir = self._validate_path(save_dir)
+        save_path = validate_path(save_path=save_path, input_file=self.input_file, ext='.json')
         indent = 4 if pretty else None
 
         # Save the entire parsed EVR dictionary as a JSON file
-        output_file_path = os.path.join(save_dir, self.filename) + '.json'
-        with open(output_file_path, 'w') as f:
+        with open(save_path, 'w') as f:
             f.write(json.dumps(self.output_data, indent=indent))
-        self._output_path.append(output_file_path)
+        self._output_path.append(str(save_path))
 
     def to_csv(self):
         """Base method for saving to a csv file"""

--- a/echoregions/convert/ev_parser.py
+++ b/echoregions/convert/ev_parser.py
@@ -20,8 +20,6 @@ class EvParserBase():
 
     @property
     def input_file(self):
-        if self._input_file is None:
-            raise ValueError("No input file to parse")
         return self._input_file
 
     @input_file.setter

--- a/echoregions/convert/evl_parser.py
+++ b/echoregions/convert/evl_parser.py
@@ -12,9 +12,10 @@ class LineParser(EvParserBase):
 
     def _parse(self, fid, replace_nan_range_value=None):
         # Read header containing metadata about the EVL file
-        filetype, file_format_number, ev_version = self.read_line(fid, True)
+        file_type, file_format_number, ev_version = self.read_line(fid, True)
         file_metadata = {
-            'filetype': filetype,
+            'file_name': os.path.splitext(os.path.basename(self.input_file))[0],
+            'file_type': file_type,
             'file_format_number': file_format_number,
             'echoview_version': ev_version
         }

--- a/echoregions/convert/evl_parser.py
+++ b/echoregions/convert/evl_parser.py
@@ -1,6 +1,6 @@
 import pandas as pd
 import os
-from .utils import parse_time
+from .utils import parse_time, validate_path
 from .ev_parser import EvParserBase
 
 
@@ -32,19 +32,19 @@ class LineParser(EvParserBase):
             }
         return file_metadata, points
 
-    def to_csv(self, save_dir=None):
+    def to_csv(self, save_path=None):
         """Convert an Echoview lines .evl file to a .csv file
 
         Parameters
         ----------
-        save_dir : str
-            directory to save the CSV file to
+        save_path : str
+            path to save the CSV file to
         """
         if not self.output_data:
             self.parse_file()
 
         # Check if the save directory is safe
-        save_dir = self._validate_path(save_dir)
+        save_path = validate_path(save_path=save_path, input_file=self.input_file, ext='.csv')
 
         # Save a row for each point
         df = pd.concat(
@@ -58,9 +58,8 @@ class LineParser(EvParserBase):
             df[k] = v
 
         # Reorder columns and export to csv
-        output_file_path = os.path.join(save_dir, self.filename) + '.csv'
-        df.to_csv(output_file_path, index=False)
-        self._output_path.append(output_file_path)
+        df.to_csv(save_path, index=False)
+        self._output_path.append(save_path)
 
     def convert_points(self, points, convert_time=True, replace_nan_range_value=None):
         """Convert x and y values of points from the EV format.

--- a/echoregions/convert/evl_parser.py
+++ b/echoregions/convert/evl_parser.py
@@ -59,7 +59,7 @@ class LineParser(EvParserBase):
 
         # Reorder columns and export to csv
         df.to_csv(save_path, index=False)
-        self._output_path.append(save_path)
+        self._output_file.append(save_path)
 
     def convert_points(self, points, convert_time=True, replace_nan_range_value=None):
         """Convert x and y values of points from the EV format.

--- a/echoregions/convert/evr_parser.py
+++ b/echoregions/convert/evr_parser.py
@@ -60,9 +60,10 @@ class Region2DParser(EvParserBase):
             return points
 
         # Read header containing metadata about the EVR file
-        filetype, file_format_number, echoview_version = self.read_line(fid, True)
+        file_type, file_format_number, echoview_version = self.read_line(fid, True)
         file_metadata = {
-            'filetype': filetype,
+            'file_name': os.path.splitext(os.path.basename(self.input_file))[0],
+            'file_type': file_type,
             'file_format_number': file_format_number,
             'echoview_version': echoview_version
         }
@@ -201,9 +202,9 @@ class Region2DParser(EvParserBase):
                     parse_time(region['metadata']['bounding_rectangle_left_x'])
             if convert_range_edges:
                 region['metadata']['bounding_rectangle_top_y'] =\
-                     self.swap_range_edge(region['metadata']['bounding_rectangle_top_y'])
+                    self.swap_range_edge(region['metadata']['bounding_rectangle_top_y'])
                 region['metadata']['bounding_rectangle_bottom_y'] =\
-                     self.swap_range_edge(region['metadata']['bounding_rectangle_bottom_y'])
+                    self.swap_range_edge(region['metadata']['bounding_rectangle_bottom_y'])
             region['points'] = self.convert_points(region['points'], convert_time, convert_range_edges)
 
     def convert_points(self, points, convert_time=True, convert_range_edges=True):

--- a/echoregions/convert/evr_parser.py
+++ b/echoregions/convert/evr_parser.py
@@ -130,7 +130,7 @@ class Region2DParser(EvParserBase):
         save_path = validate_path(save_path=save_path, input_file=self.input_file, ext='.csv')
         # Export to csv
         self.to_dataframe().to_csv(save_path, index=False)
-        self._output_path.append(save_path)
+        self._output_file.append(save_path)
 
     def get_points_from_region(self, region, file=None):
         if file is not None:

--- a/echoregions/convert/evr_parser.py
+++ b/echoregions/convert/evr_parser.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 import os
 import copy
 from .ev_parser import EvParserBase
-from .utils import parse_time, from_JSON
+from .utils import parse_time, from_JSON, validate_path
 
 
 class Region2DParser(EvParserBase):
@@ -94,17 +94,15 @@ class Region2DParser(EvParserBase):
 
         return file_metadata, regions
 
-    def to_csv(self, save_dir=None, **kwargs):
+    def to_dataframe(self, **kwargs):
         # Parse EVR file if it hasn't already been done
         if not self.output_data:
             self.parse_file(**kwargs)
-        # Check if the save directory is safe
-        save_dir = self._validate_path(save_dir)
-        row = []
 
         df = pd.DataFrame()
         # Save file metadata for each point
         metadata = pd.Series(self.output_data['metadata'])
+        row = []
         # Loop over each region
         for rid, region in self.output_data['regions'].items():
             # Save region information for each point
@@ -121,10 +119,18 @@ class Region2DParser(EvParserBase):
                 })
                 row = pd.concat([region_id, point, metadata, region_metadata, region_notes, detection_settings])
                 df = df.append(row, ignore_index=True)
-        # Reorder columns and export to csv
-        output_file_path = os.path.join(save_dir, self.filename) + '.csv'
-        df[row.keys()].to_csv(output_file_path, index=False)
-        self._output_path.append(output_file_path)
+        # Reorder columns
+        return df[row.keys()]
+
+    def to_csv(self, save_path=None, **kwargs):
+        # Parse EVR file if it hasn't already been done
+        if not self.output_data:
+            self.parse_file(**kwargs)
+        # Check if the save directory is safe
+        save_path = validate_path(save_path=save_path, input_file=self.input_file, ext='.csv')
+        # Export to csv
+        self.to_dataframe().to_csv(save_path, index=False)
+        self._output_path.append(save_path)
 
     def get_points_from_region(self, region, file=None):
         if file is not None:

--- a/echoregions/convert/evr_parser.py
+++ b/echoregions/convert/evr_parser.py
@@ -115,8 +115,8 @@ class Region2DParser(EvParserBase):
             for p, point in enumerate(region['points'].values()):
                 point = pd.Series({
                     'point_idx': str(p),
-                    'x': point[0],
-                    'y': point[1],
+                    'ping_time': point[0],
+                    'depth': point[1],
                 })
                 row = pd.concat([region_id, point, metadata, region_metadata, region_notes, detection_settings])
                 df = df.append(row, ignore_index=True)

--- a/echoregions/convert/merge.py
+++ b/echoregions/convert/merge.py
@@ -1,0 +1,29 @@
+def merge(objects, reindex_ids=False):
+    """Merge echoregion objects.
+    Currently only supports merging Regions2D objects.
+
+    Parameters
+    ----------
+    objects : list
+        a list collection of Regions2D objects
+
+    Returns
+    -------
+    combined : Regions2D
+        A Regions2D object with region ids prepended by the EVR original filename.
+    """
+    if not isinstance(objects, list):
+        return ValueError("`merge` takes a list of Regions2D objects")
+    merged_idx = []
+    merged_data = []
+    for regions in objects:
+        if not regions.output_data:
+            raise ValueError("EVR file has not been parsed. Call `parse_file` first.")
+        merged_data += regions.output_data['regions'].values()
+        if reindex_ids:
+            merged_idx += list(range(len(regions.output_data['regions'])))
+        else:
+            merged_idx += [f"{regions.output_data['metadata']['file_name']}_{r}"
+                           for r in regions.region_ids]
+    merged = dict(zip(merged_idx, merged_data))
+    return merged

--- a/echoregions/convert/merge.py
+++ b/echoregions/convert/merge.py
@@ -1,3 +1,6 @@
+from ..formats.regions2d import Regions2D
+
+
 def merge(objects, reindex_ids=False):
     """Merge echoregion objects.
     Currently only supports merging Regions2D objects.
@@ -12,8 +15,9 @@ def merge(objects, reindex_ids=False):
     combined : Regions2D
         A Regions2D object with region ids prepended by the EVR original filename.
     """
-    if not isinstance(objects, list):
+    if not isinstance(objects, list) or not all(isinstance(o, Regions2D) for o in objects):
         return ValueError("`merge` takes a list of Regions2D objects")
+
     merged_idx = []
     merged_data = []
     for regions in objects:
@@ -25,5 +29,15 @@ def merge(objects, reindex_ids=False):
         else:
             merged_idx += [f"{regions.output_data['metadata']['file_name']}_{r}"
                            for r in regions.region_ids]
+    # Attach region information to region ids
     merged = dict(zip(merged_idx, merged_data))
-    return merged
+    # Create new Regons2D object
+    merged_obj = Regions2D()
+    # Populate metadata
+    merged_obj.output_data['metadata'] = objects[0].output_data['metadata']
+    # Combine metadata of all Regions2D objects
+    for field in objects[0].output_data['metadata'].keys():
+        merged_obj.output_data['metadata'][field] = [o.output_data['metadata'][field] for o in objects]
+    # Set region data
+    merged_obj.output_data['regions'] = merged
+    return merged_obj

--- a/echoregions/convert/utils.py
+++ b/echoregions/convert/utils.py
@@ -3,6 +3,7 @@ import os
 import json
 import datetime as dt
 import numpy as np
+from pathlib import Path
 
 EK60_fname_pattern = r'(?P<survey>.+)?-?D(?P<date>\w{1,8})-T(?P<time>\w{1,6})-?(?P<postfix>\w+)?\..+'
 
@@ -24,6 +25,40 @@ def from_JSON(j):
         except json.decoder.JSONDecodeError:
             raise ValueError("Invalid JSON string")
     return data_dict
+
+
+def validate_path(save_path=None, input_file=None, ext='.json'):
+    # Check if save_path is specified.
+    # If not try to create one with the input_file and ext
+
+    if save_path is None:
+        if input_file is None:
+            raise ValueError("No paths given")
+        elif ext is None:
+            raise ValueError("No extension given")
+        else:
+            input_file = Path(input_file)
+            save_path = input_file.parent / (input_file.stem + ext)
+    # If save path is specified, check if folders need to be made
+    else:
+        save_path = Path(save_path)
+        # If save path is a directory, use name of input file
+        if save_path.suffix == '':
+            if input_file is None:
+                raise ValueError("No filename given")
+            else:
+                input_file = Path(input_file)
+                save_path = save_path / (input_file.stem + ext)
+
+    # Check if extension of save path matches desired file format
+    if save_path.suffix.lower() != ext.lower():
+        raise ValueError(f"{save_path} is not a {ext} file")
+
+    # Create directories if they do not exist
+    if not save_path.parent.is_dir():
+        save_path.parent.mkdir(parents=True, exist_ok=True)
+
+    return str(save_path)
 
 
 def parse_time(ev_time, datetime_format='D%Y%m%dT%H%M%S%f'):

--- a/echoregions/convert/utils.py
+++ b/echoregions/convert/utils.py
@@ -6,6 +6,7 @@ import numpy as np
 
 EK60_fname_pattern = r'(?P<survey>.+)?-?D(?P<date>\w{1,8})-T(?P<time>\w{1,6})-?(?P<postfix>\w+)?\..+'
 
+
 def from_JSON(j):
     """ Opens a JSON file
 
@@ -23,6 +24,7 @@ def from_JSON(j):
         except json.decoder.JSONDecodeError:
             raise ValueError("Invalid JSON string")
     return data_dict
+
 
 def parse_time(ev_time, datetime_format='D%Y%m%dT%H%M%S%f'):
     """Convert EV datetime to a numpy datetime64 object
@@ -45,6 +47,7 @@ def parse_time(ev_time, datetime_format='D%Y%m%dT%H%M%S%f'):
     elif not isinstance(ev_time, str):
         raise ValueError("'ev_time' must be type str")
     return np.array(dt.datetime.strptime(ev_time, datetime_format), dtype=np.datetime64)
+
 
 def parse_filetime(fname):
     """Convert Simrad-style datetime to a numpy datetime64 object

--- a/echoregions/formats/__init__.py
+++ b/echoregions/formats/__init__.py
@@ -1,1 +1,2 @@
 from .regions2d import Regions2D
+from .multi import MultiRegions2D

--- a/echoregions/formats/multi.py
+++ b/echoregions/formats/multi.py
@@ -1,0 +1,106 @@
+import pandas as pd
+import json
+from ..convert.utils import validate_path
+from .regions2d import Regions2D
+
+
+class MultiRegions2D():
+    """Container for many Regions2D objects
+    """
+    def __init__(self, objects):
+        """Initialize object
+
+        Parameters
+        ----------
+        objects : list
+            list of parsed Regions2D objects or paths to EVR files.
+            The EVR files will be parsed without point conversion.
+        """
+        if not isinstance(objects, list):
+            raise ValueError("Input is not a list")
+
+        self._files = None
+
+        if all(isinstance(f, str) for f in objects):
+            self._files = [Regions2D(f) for f in objects]
+        elif all(isinstance(f, Regions2D) for f in objects):
+            if all([bool(f.output_data) for f in objects]):
+                self._files = objects
+            else:
+                raise ValueError("Not all `Regions2D` objects are parsed")
+        else:
+            raise ValueError("Input types are not all `str` or `Regions2D` objects.")
+
+        self._output_file = []
+        self._output_data = None
+
+    def __getitem__(self, key):
+        key = str(key)
+        if key not in self.files:
+            raise KeyError(f"{key} is not a valid region filename")
+        return self.files[key]
+
+    @property
+    def files(self):
+        return self._files
+
+    @files.setter
+    def files(self, objects):
+        fnames = [r.output_data['metadata']['file_name'] for r in objects]
+        self._files = dict(zip(fnames, objects))
+
+    @property
+    def output_file(self):
+        if len(self._output_file) == 1:
+            self._output_file = list(set(self._output_file))
+            return self._output_file[0]
+        else:
+            return self._output_file
+
+    @property
+    def output_data(self):
+        if self._output_data is None:
+            self._output_data = {
+                f.output_data['metadata']['file_name']: f.output_data
+                for f in self.files
+            }
+        return self._output_data
+
+    def to_dataframe(self):
+        """Concatenates the data of all Region2D files and returns a pandas DataFrame
+        """
+        df = pd.concat([r.to_dataframe() for r in self.files])
+        return df
+
+    def to_csv(self, save_path=None):
+        """Save multiple Region2D objects to a single CSV file.
+
+        Parameters
+        ----------
+        save_path : str
+            If save_path is not provided, the file will be saved with the filename of
+            the first EVR file at the same location as the EVR file.
+        """
+        save_path = validate_path(save_path=save_path, input_file=self.files[0].input_file, ext='.csv')
+        self.to_dataframe().to_csv(save_path, index=False)
+        self._output_file.append(save_path)
+
+    def to_json(self, save_path=None, pretty=False):
+        """Save multiple Region2D objects to a single CSV file.
+
+        Parameters
+        ----------
+        save_path : str
+            If save_path is not provided, the file will be saved with the filename of
+            the first EVR file at the same location as the EVR file.
+        pretty : bool
+            Whether or not to format JSON to be more human readable.
+            Defaults to `False`
+        """
+        save_path = validate_path(save_path=save_path, input_file=self.files[0].input_file, ext='.json')
+        indent = 4 if pretty else None
+
+        # Save the entire parsed EVR dictionary as a JSON file
+        with open(save_path, 'w') as f:
+            f.write(json.dumps(self.output_data, indent=indent))
+        self._output_file.append(save_path)

--- a/echoregions/formats/regions2d.py
+++ b/echoregions/formats/regions2d.py
@@ -30,8 +30,12 @@ class Regions2D():
         return self.parser.output_data
 
     @property
-    def output_path(self):
-        return self.parser.output_path
+    def output_file(self):
+        return self.parser.output_file
+
+    @property
+    def input_file(self):
+        return self.parser.input_file
 
     @property
     def raw_range(self):

--- a/echoregions/formats/regions2d.py
+++ b/echoregions/formats/regions2d.py
@@ -102,11 +102,13 @@ class Regions2D():
         """
         self.parser.parse_file(convert_time=convert_time, convert_range_edges=convert_range_edges)
 
-    def to_csv(self, save_dir=None, convert_time=False, convert_range_edges=True):
-        """Convert EVR to CSV
+    def to_csv(self, save_path=None, convert_time=False, convert_range_edges=True):
+        """Convert an EVR file to a CSV
 
         Parameters
         ----------
+        save_path : str
+            Path to save csv file to
         convert_time : bool
             Whether or not to convert times in the EV datetime format to numpy datetime64.
             Default to `False`.
@@ -115,13 +117,21 @@ class Regions2D():
             Set the values by assigning range values to `min_range` and `max_range`
             or by passing a file into `set_range_edge_from_raw`. Defaults to True
         """
-        self.parser.to_csv(save_dir=save_dir, convert_time=False, convert_range_edges=convert_range_edges)
+        self.parser.to_csv(save_path=save_path, convert_time=convert_time, convert_range_edges=convert_range_edges)
 
-    def to_json(self, save_dir=None, convert_range_edges=True, pretty=False):
+    def to_dataframe(self, convert_time=False, convert_range_edges=True):
+        """Organize EVR data into a Pandas DataFrame.
+        See `Regions2D.to_csv` for arguments
+        """
+        return self.parser.to_dataframe(convert_time=convert_time, convert_range_edges=convert_range_edges)
+
+    def to_json(self, save_path=None, convert_range_edges=True, pretty=False):
         """Convert EVR to JSON
 
         Parameters
         ----------
+        save_path : str
+            Path to save csv file to
         convert_range_edges : bool
             Whether or not to convert -9999.99 and -9999.99 range edges to real values for EVR files.
             Set the values by assigning range values to `min_range` and `max_range`
@@ -129,7 +139,7 @@ class Regions2D():
         pretty : bool
             Whether or not to output more human readable JSON
         """
-        self.parser.to_json(save_dir=save_dir, pretty=pretty, convert_range_edges=convert_range_edges)
+        self.parser.to_json(save_path=save_path, pretty=pretty, convert_range_edges=convert_range_edges)
 
     def get_points_from_region(self, region, file=None):
         """Get points from specified region from a JSON or CSV file
@@ -187,7 +197,7 @@ class Regions2D():
 
     def convert_output(self, convert_time=True, convert_range_edges=True):
         """Convert x and y values of points from the EV format.
-        Modifies Regions2d.output_data
+        Modifies Regions2d.output_data. See convert_points for arguments.f
         """
         self.parser.convert_output(convert_time=convert_time, convert_range_edges=convert_range_edges)
 

--- a/echoregions/formats/regions2d.py
+++ b/echoregions/formats/regions2d.py
@@ -1,14 +1,20 @@
-from numpy.lib.arraysetops import isin
 from ..convert import Region2DParser, utils
 from ..plot.region_plot import Region2DPlotter
 import numpy as np
 
+
 class Regions2D():
-    def __init__(self, input_file=None):
-        self.parser = Region2DParser(input_file)
+    def __init__(self, input_file=None, parse=True, convert_time=False,
+                 convert_range_edges=True, min_depth=None, max_depth=None):
         self._plotter = None
         self._region_ids = None
         self._region_classifications = None
+
+        self.parser = Region2DParser(input_file)
+        self.max_depth = max_depth
+        self.min_depth = min_depth
+        if parse:
+            self.parse_file(convert_time=convert_time, convert_range_edges=convert_range_edges)
 
     def __iter__(self):
         return iter(self.output_data['regions'].values())
@@ -52,14 +58,14 @@ class Regions2D():
         if self.min_depth is not None:
             if val <= self.min_depth:
                 raise ValueError("max_depth cannot be less than min_depth")
-        self.parser.max_depth = float(val)
+        self.parser.max_depth = float(val) if val is not None else val
 
     @min_depth.setter
     def min_depth(self, val):
         if self.max_depth is not None:
             if val >= self.max_depth:
                 raise ValueError("min_depth cannot be greater than max_depth")
-        self.parser.min_depth = float(val)
+        self.parser.min_depth = float(val) if val is not None else val
 
     @property
     def plotter(self):
@@ -285,4 +291,4 @@ class Regions2D():
         return {
             k: v['metadata']['region_classification']
             for k, v in self.output_data['regions'].items()
-            }
+        }

--- a/echoregions/formats/regions2d.py
+++ b/echoregions/formats/regions2d.py
@@ -7,7 +7,7 @@ class Regions2D():
     def __init__(self, input_file=None):
         self.parser = Region2DParser(input_file)
         self._plotter = None
-        self._regions = None
+        self._region_ids = None
         self._region_classifications = None
 
     def __iter__(self):
@@ -70,10 +70,10 @@ class Regions2D():
         return self._plotter
 
     @property
-    def regions(self):
-        if self._regions is None:
-            self._regions = self.get_regions()
-        return self._regions
+    def region_ids(self):
+        if self._region_ids is None:
+            self._region_ids = self.get_region_ids()
+        return self._region_ids
 
     @property
     def region_classifications(self):
@@ -260,7 +260,7 @@ class Regions2D():
         else:
             return files
 
-    def get_regions(self):
+    def get_region_ids(self):
         """Get the ids of all regions in the EVR file
 
         Returns

--- a/echoregions/plot/region_plot.py
+++ b/echoregions/plot/region_plot.py
@@ -1,11 +1,10 @@
 import numpy as np
 import matplotlib.pyplot as plt
-from ..convert import Region2DParser
+
 
 class Region2DPlotter():
     def __init__(self, Regions2D):
         self.Regions2D = Regions2D
-
 
     def plot_region(self, region, offset=0):
         points = np.array(self.Regions2D.convert_points(

--- a/echoregions/tests/test_ev_parser.py
+++ b/echoregions/tests/test_ev_parser.py
@@ -14,6 +14,7 @@ def test_parse_time():
     timestamp = 'D20170625T1539223320'
     assert parse_time(timestamp) == np.datetime64('2017-06-25T15:39:22.3320')
 
+
 def test_plotting_points():
     # Test converting points in EV format to plottable values (datetime64 and float)
     evl_paths = data_dir + 'x1.bottom.evl'
@@ -28,6 +29,7 @@ def test_plotting_points():
 
     os.remove(l_parser.output_path)
     os.rmdir(output_json)
+
 
 def test_convert_ecs():
     # Test converting an EV calibration file (ECS)

--- a/echoregions/tests/test_ev_parser.py
+++ b/echoregions/tests/test_ev_parser.py
@@ -27,7 +27,7 @@ def test_plotting_points():
     assert len(x) == 13764
     assert len(y) == 13764
 
-    os.remove(l_parser.output_path)
+    os.remove(l_parser.output_file)
     os.rmdir(output_json)
 
 
@@ -40,7 +40,7 @@ def test_convert_ecs():
     parser.to_csv(output_csv)
     parser.to_json(output_json)
 
-    for path in parser.output_path:
+    for path in parser.output_file:
         assert os.path.exists(path)
         os.remove(path)
 
@@ -56,7 +56,7 @@ def test_convert_evl():
     parser.to_csv(output_csv)
     parser.to_json(output_json)
 
-    for path in parser.output_path:
+    for path in parser.output_file:
         assert os.path.exists(path)
         os.remove(path)
 

--- a/echoregions/tests/test_parse_evr.py
+++ b/echoregions/tests/test_parse_evr.py
@@ -6,6 +6,7 @@ data_dir = './echoregions/test_data/ek60/'
 output_csv = data_dir + 'output_CSV/'
 output_json = data_dir + 'output_JSON/'
 
+
 def test_convert_evr():
     # Test converting EV regions file (EVR)
     evr_path = data_dir + 'x1.evr'
@@ -14,15 +15,16 @@ def test_convert_evr():
     r2d.to_json(output_json)
     r2d.to_csv(output_csv)
     points = r2d.get_points_from_region(4)
-    points = r2d.get_points_from_region(4, r2d.output_path[0])
+    points = r2d.get_points_from_region(4, r2d.output_file[0])
     assert points[0] == ['D20170625T1539223320', '9.2447583998']
 
-    for path in r2d.output_path:
+    for path in r2d.output_file:
         assert os.path.exists(path)
         os.remove(path)
 
     os.rmdir(output_csv)
     os.rmdir(output_json)
+
 
 def test_plotting_points():
     # Test converting points in EV format to plottable values (datetime64 and float)
@@ -36,8 +38,9 @@ def test_plotting_points():
     y = evr_points[:, 1]
     assert all(y == [r_parser.min_depth, r_parser.max_depth, r_parser.max_depth, r_parser.min_depth])
 
-    os.remove(r_parser.output_path)
+    os.remove(r_parser.output_file)
     os.rmdir(output_json)
+
 
 def test_file_select():
     # Test file selection based on region bounds


### PR DESCRIPTION
A list of Regions2D objects can be merged with `echoregions.merge([obj1, obj2, ...])`
or wrapped with `echoregions.MultiRegions2D([obj1, obj2, ...])`.

This PR also cleans up the code and moves validate_path to utils.