### PR TITLE
Fix bug in the `close_region` call in `Regions2D.plot`

### DIFF
--- a/echoregions/regions2d/regions2d.py
+++ b/echoregions/regions2d/regions2d.py
@@ -361,7 +361,7 @@ class Regions2D:
         region = self.select_region(region)
 
         if close_region:
-            region = self.Regions2D.close_region(region)
+            region = self.close_region(region)
         for _, row in region.iterrows():
             plt.plot(row["time"], row["depth"], **kwargs)
 


### PR DESCRIPTION
This is a small bug fix that remove the wrong reference of `self.Regions2D.close_region` in `Regions2D.plot`. `self` is already the `Regions2D` object.