### PR TITLE
Use Kwargs** for Line Mask Interpolation

### DIFF
--- a/echoregions/lines/lines.py
+++ b/echoregions/lines/lines.py
@@ -221,7 +221,9 @@ class Lines:
                 set(list(pd.DataFrame(sonar_ping_time)[0]) + list(filtered_bottom.index))
             )
 
-            # Interpolate on the sonar coordinates.
+            # Interpolate on the sonar coordinates. Note that some interpolation kwaargs
+            # will result in some interpolation NaN values. The ffill and bfill lines
+            # are there to fill in these NaN values.
             # TODO There exists a problem where when we use .loc prior to reindexing
             # we are hit with a key not found error.
             bottom_contours = (
@@ -229,6 +231,8 @@ class Lines:
                 .reindex(joint_index)
                 .interpolate(**kwargs)
                 .loc[sonar_ping_time]
+                .ffill()
+                .bfill()
             )
 
             # convert to data array for bottom

--- a/echoregions/lines/lines.py
+++ b/echoregions/lines/lines.py
@@ -221,8 +221,7 @@ class Lines:
                 set(list(pd.DataFrame(sonar_ping_time)[0]) + list(filtered_bottom.index))
             )
 
-            # Interpolate on the sonar coordinates. Note that nearest interpolation
-            # has a problem when points are far from each other.
+            # Interpolate on the sonar coordinates.
             # TODO There exists a problem where when we use .loc prior to reindexing
             # we are hit with a key not found error.
             bottom_contours = (

--- a/echoregions/tests/test_lines.py
+++ b/echoregions/tests/test_lines.py
@@ -223,7 +223,7 @@ def test_lines_mask(lines_fixture: Lines, da_Sv_fixture: DataArray) -> None:
         DataArray containing Sv data of test zarr file.
     """
 
-    M, bottom_contours = lines_fixture.mask(da_Sv_fixture.isel(channel=0))
+    M, bottom_contours = lines_fixture.mask(da_Sv_fixture.isel(channel=0), method="slinear")
 
     # Compute unique values
     unique_values = np.unique(M.compute().data, return_counts=True)

--- a/echoregions/tests/test_lines.py
+++ b/echoregions/tests/test_lines.py
@@ -223,7 +223,13 @@ def test_lines_mask(lines_fixture: Lines, da_Sv_fixture: DataArray) -> None:
         DataArray containing Sv data of test zarr file.
     """
 
-    M, bottom_contours = lines_fixture.mask(da_Sv_fixture.isel(channel=0), method="slinear")
+    M, bottom_contours = lines_fixture.mask(
+        da_Sv_fixture.isel(channel=0),
+        method="slinear",
+        limit=5,
+        limit_area=None,
+        limit_direction="both",
+    )
 
     # Compute unique values
     unique_values = np.unique(M.compute().data, return_counts=True)


### PR DESCRIPTION
Used Kwargs** for Line Mask Interpolation, and modified test to make use of `slinear` interpolation. This addresses #151.